### PR TITLE
Add kid header to JWTs

### DIFF
--- a/go/signing.go
+++ b/go/signing.go
@@ -32,6 +32,7 @@ func generateJWTEmbedURl() string {
 		"teams":        [...]string{"EmbedTeam"},
 		"account_type": "Pro",
 	})
+	token.Header["kid"] = clientID
 
 	tokenString, err := token.SignedString([]byte(embedSecret))
 

--- a/python/signing.py
+++ b/python/signing.py
@@ -67,7 +67,12 @@ def generateJWTEmbedUrl():
         "account_type": "Pro",
         "teams": ["Embedded Users", "EmbeddingTown"],
     }
-    token = jwt.encode(payload=payload, key=EMBED_SECRET, algorithm="HS256")
+    token = jwt.encode(
+        payload=payload,
+        key=EMBED_SECRET,
+        algorithm="HS256",
+        headers={ "kid": CLIENT_ID },
+    )
     url_with_token = (
         "https://app.sigmacomputing.com/<your org>/<your workbook>?:embed=true&:jwt="
         + token

--- a/ruby/signing.rb
+++ b/ruby/signing.rb
@@ -47,7 +47,7 @@ def generate_jwt_embed_url()
     "account_type": "Pro",
     "teams": ["EmbedTeam"],
   }
-  token = JWT.encode(payload, EMBED_SECRET, 'HS256')
+  token = JWT.encode(payload, EMBED_SECRET, 'HS256', { "kid": CLIENT_ID })
   return "https://app.sigmacomputing.com/<your-org>/<your-workbook>?:embed=true&:jwt=#{token}"
 end
 


### PR DESCRIPTION
We aren't setting the `kid` header for the current JWT examples.